### PR TITLE
🍕 Feat; add attempts backend 

### DIFF
--- a/backend/prisma/migrations/20250526162451_/migration.sql
+++ b/backend/prisma/migrations/20250526162451_/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `timestamp` on the `Attempt` table. All the data in the column will be lost.
+  - You are about to drop the column `userId` on the `Ranking` table. All the data in the column will be lost.
+  - Added the required column `updatedAt` to the `Attempt` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Ranking" DROP CONSTRAINT "Ranking_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "Attempt" DROP COLUMN "timestamp",
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Ranking" DROP COLUMN "userId";
+
+-- CreateTable
+CREATE TABLE "_RankingToUser" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_RankingToUser_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_RankingToUser_B_index" ON "_RankingToUser"("B");
+
+-- AddForeignKey
+ALTER TABLE "_RankingToUser" ADD CONSTRAINT "_RankingToUser_A_fkey" FOREIGN KEY ("A") REFERENCES "Ranking"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_RankingToUser" ADD CONSTRAINT "_RankingToUser_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -52,7 +52,8 @@ model Attempt {
   wordId             String
   translation_method String
   is_correct         Boolean
-  timestamp          DateTime
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
   session            Session  @relation(fields: [sessionId], references: [id])
   word               Word     @relation(fields: [wordId], references: [id])
 }

--- a/backend/src/controllers/attempts/attempt-controller.ts
+++ b/backend/src/controllers/attempts/attempt-controller.ts
@@ -1,0 +1,37 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+import type { CreateAttemptDTO, UpdateAttemptDTO } from "../../types/attempts/attempt-type";
+
+import { AttemptService } from "../../services/attempts/attempt-service";
+
+export class AttemptController {
+  constructor(private attemptService = new AttemptService()) {}
+
+  async create(request: FastifyRequest<{ Body: CreateAttemptDTO }>, reply: FastifyReply) {
+    const attempt = await this.attemptService.create(request.body);
+    return reply.status(201).send(attempt);
+  }
+
+  async list(request: FastifyRequest, reply: FastifyReply) {
+    const attempts = await this.attemptService.list();
+    return reply.send(attempts);
+  }
+
+  async findById(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) {
+    const attempt = await this.attemptService.findById(request.params.id);
+    return reply.send(attempt);
+  }
+
+  async update(
+    request: FastifyRequest<{ Params: { id: string }; Body: UpdateAttemptDTO }>,
+    reply: FastifyReply,
+  ) {
+    const attempt = await this.attemptService.update(request.params.id, request.body);
+    return reply.send(attempt);
+  }
+
+  async delete(request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) {
+    await this.attemptService.delete(request.params.id);
+    return reply.status(204).send();
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import cors from "@fastify/cors";
 import dotenv from "dotenv";
 import fastify from "fastify";
 
+import attemptRoutes from "./routes/attempts";
 import userRoutes from "./routes/users/index";
 
 dotenv.config();
@@ -59,6 +60,9 @@ async function build() {
 
     // Registra as rotas de usuários
     await app.register(userRoutes, { prefix: "/api" });
+
+    // Registra as rotas de tentativas
+    await app.register(attemptRoutes, { prefix: "/api" });
 
     return app;
   }

--- a/backend/src/repositories/attempts/attempt-repository.ts
+++ b/backend/src/repositories/attempts/attempt-repository.ts
@@ -1,0 +1,36 @@
+import type { CreateAttemptDTO, UpdateAttemptDTO } from "../../types/attempts/attempt-type";
+
+import { PrismaClient } from "../../generated/prisma";
+
+export class AttemptRepository {
+  constructor(private prisma = new PrismaClient()) {}
+
+  async create(data: CreateAttemptDTO) {
+    return this.prisma.attempt.create({
+      data,
+    });
+  }
+
+  async list() {
+    return this.prisma.attempt.findMany();
+  }
+
+  async findById(id: string) {
+    return this.prisma.attempt.findUnique({
+      where: { id },
+    });
+  }
+
+  async update(id: string, data: UpdateAttemptDTO) {
+    return this.prisma.attempt.update({
+      where: { id },
+      data,
+    });
+  }
+
+  async delete(id: string) {
+    return this.prisma.attempt.delete({
+      where: { id },
+    });
+  }
+}

--- a/backend/src/routes/attempts/index.ts
+++ b/backend/src/routes/attempts/index.ts
@@ -1,0 +1,36 @@
+import type { FastifyInstance } from "fastify";
+
+import { AttemptController } from "../../controllers/attempts/attempt-controller";
+import {
+  createAttemptSchema,
+  deleteAttemptSchema,
+  getAllAttemptsSchema,
+  getAttemptSchema,
+  updateAttemptSchema,
+} from "../../schemas/attempts/attempt-schema";
+
+export async function attemptRoutes(app: FastifyInstance) {
+  const attemptController = new AttemptController();
+
+  app.post("/attempts", {
+    schema: createAttemptSchema,
+  }, attemptController.create.bind(attemptController));
+
+  app.get("/attempts", {
+    schema: getAllAttemptsSchema,
+  }, attemptController.list.bind(attemptController));
+
+  app.get("/attempts/:id", {
+    schema: getAttemptSchema,
+  }, attemptController.findById.bind(attemptController));
+
+  app.put("/attempts/:id", {
+    schema: updateAttemptSchema,
+  }, attemptController.update.bind(attemptController));
+
+  app.delete("/attempts/:id", {
+    schema: deleteAttemptSchema,
+  }, attemptController.delete.bind(attemptController));
+}
+
+export default attemptRoutes;

--- a/backend/src/schemas/attempts/attempt-schema.ts
+++ b/backend/src/schemas/attempts/attempt-schema.ts
@@ -1,0 +1,98 @@
+import { Type } from "@fastify/type-provider-typebox";
+
+export const createAttemptSchema = {
+  tags: ["attempts"],
+  description: "Criar uma nova tentativa",
+  body: Type.Object({
+    sessionId: Type.String(),
+    wordId: Type.String(),
+    translation_method: Type.String(),
+    is_correct: Type.Boolean(),
+  }),
+  response: {
+    201: Type.Object({
+      id: Type.String(),
+      sessionId: Type.String(),
+      wordId: Type.String(),
+      translation_method: Type.String(),
+      is_correct: Type.Boolean(),
+      createdAt: Type.String({ format: "date-time" }),
+      updatedAt: Type.String({ format: "date-time" }),
+    }),
+  },
+};
+
+export const updateAttemptSchema = {
+  tags: ["attempts"],
+  description: "Atualizar uma tentativa",
+  params: Type.Object({
+    id: Type.String(),
+  }),
+  body: Type.Partial(
+    Type.Object({
+      sessionId: Type.Optional(Type.String()),
+      wordId: Type.Optional(Type.String()),
+      translation_method: Type.Optional(Type.String()),
+      is_correct: Type.Optional(Type.Boolean()),
+    }),
+  ),
+  response: {
+    200: Type.Object({
+      id: Type.String(),
+      sessionId: Type.String(),
+      wordId: Type.String(),
+      translation_method: Type.String(),
+      is_correct: Type.Boolean(),
+      createdAt: Type.String({ format: "date-time" }),
+      updatedAt: Type.String({ format: "date-time" }),
+    }),
+  },
+};
+
+export const getAllAttemptsSchema = {
+  tags: ["attempts"],
+  description: "Listar todas as tentativas",
+  response: {
+    200: Type.Array(
+      Type.Object({
+        id: Type.String(),
+        sessionId: Type.String(),
+        wordId: Type.String(),
+        translation_method: Type.String(),
+        is_correct: Type.Boolean(),
+        createdAt: Type.String({ format: "date-time" }),
+        updatedAt: Type.String({ format: "date-time" }),
+      }),
+    ),
+  },
+};
+
+export const getAttemptSchema = {
+  tags: ["attempts"],
+  description: "Buscar uma tentativa por ID",
+  params: Type.Object({
+    id: Type.String(),
+  }),
+  response: {
+    200: Type.Object({
+      id: Type.String(),
+      sessionId: Type.String(),
+      wordId: Type.String(),
+      translation_method: Type.String(),
+      is_correct: Type.Boolean(),
+      createdAt: Type.String({ format: "date-time" }),
+      updatedAt: Type.String({ format: "date-time" }),
+    }),
+  },
+};
+
+export const deleteAttemptSchema = {
+  tags: ["attempts"],
+  description: "Deletar uma tentativa",
+  params: Type.Object({
+    id: Type.String(),
+  }),
+  response: {
+    204: Type.Null(),
+  },
+};

--- a/backend/src/services/attempts/attempt-service.ts
+++ b/backend/src/services/attempts/attempt-service.ts
@@ -1,0 +1,34 @@
+import type { CreateAttemptDTO, UpdateAttemptDTO } from "../../types/attempts/attempt-type";
+
+import { AttemptRepository } from "../../repositories/attempts/attempt-repository";
+import { AppError } from "../../utils/errors/app-error";
+
+export class AttemptService {
+  constructor(private attemptRepository = new AttemptRepository()) {}
+
+  async create(data: CreateAttemptDTO) {
+    return this.attemptRepository.create(data);
+  }
+
+  async list() {
+    return this.attemptRepository.list();
+  }
+
+  async findById(id: string) {
+    const attempt = await this.attemptRepository.findById(id);
+    if (!attempt) {
+      throw new AppError("Tentativa não encontrada", 404);
+    }
+    return attempt;
+  }
+
+  async update(id: string, data: UpdateAttemptDTO) {
+    await this.findById(id);
+    return this.attemptRepository.update(id, data);
+  }
+
+  async delete(id: string) {
+    await this.findById(id);
+    await this.attemptRepository.delete(id);
+  }
+}

--- a/backend/src/types/attempts/attempt-type.ts
+++ b/backend/src/types/attempts/attempt-type.ts
@@ -3,8 +3,6 @@ export interface CreateAttemptDTO {
   wordId: string;
   translation_method: string;
   is_correct: boolean;
-  createdAt: Date;
-  updatedAt?: Date;
 }
 
 export interface UpdateAttemptDTO {
@@ -12,7 +10,6 @@ export interface UpdateAttemptDTO {
   wordId: string;
   translation_method: string;
   is_correct: boolean;
-  updatedAt: Date;
 }
 
 export interface Attempt {
@@ -21,6 +18,4 @@ export interface Attempt {
   wordId: string;
   translation_method: string;
   is_correct: boolean;
-  createdAt: Date;
-  updatedAt: Date;
 }

--- a/backend/src/types/attempts/attempt-type.ts
+++ b/backend/src/types/attempts/attempt-type.ts
@@ -1,0 +1,26 @@
+export interface CreateAttemptDTO {
+  sessionId: string;
+  wordId: string;
+  translation_method: string;
+  is_correct: boolean;
+  createdAt: Date;
+  updatedAt?: Date;
+}
+
+export interface UpdateAttemptDTO {
+  sessionId: string;
+  wordId: string;
+  translation_method: string;
+  is_correct: boolean;
+  updatedAt: Date;
+}
+
+export interface Attempt {
+  id: string;
+  sessionId: string;
+  wordId: string;
+  translation_method: string;
+  is_correct: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
- Create Attempt DTO for create and update attempts
- Update prisma schema to include timestamps in a better way
- Implement attempt types, schemas, repository, service, controller, routes with all CRUD operations
- Register Attempt routes in main server file